### PR TITLE
Support Windows line endings with \r\n instead of just \n.

### DIFF
--- a/menu/menu.go
+++ b/menu/menu.go
@@ -41,7 +41,7 @@ func NewMenuOptions(prompt string, length int, menuCommand string) MenuOptions {
 
 // Trim whitespace, newlines, and create command+arguments slice
 func cleanCommand(cmd string) ([]string, error) {
-	cmd_args := strings.Split(strings.Trim(cmd, " \n"), " ")
+	cmd_args := strings.Split(strings.Trim(cmd, " \r\n"), " ")
 	return cmd_args, nil
 }
 

--- a/menu/menu_test.go
+++ b/menu/menu_test.go
@@ -9,10 +9,22 @@ import (
 const cmd = "cmd"
 const desc = "this is a command"
 
+const cmdwin = "cmdwin"
+const descwin = "this is a windows command"
+
+var cmdwininvoked bool
+var cmdwinargs []string
+
 func getOpts() []CommandOption {
 	return []CommandOption{
 		CommandOption{cmd, desc, func(...string) error {
 			fmt.Println("in function")
+			return nil
+		}},
+		CommandOption{cmdwin, descwin, func(args ...string) error {
+			fmt.Println("in cmdwin function")
+			cmdwininvoked = true
+			cmdwinargs = args
 			return nil
 		}},
 	}
@@ -94,4 +106,52 @@ func TestGoodInput(t *testing.T) {
 
 	input := bytes.NewReader([]byte(fmt.Sprintf("%s\n", cmd)))
 	menu.start(input)
+}
+
+// Test Windows commands, which will have "\r\n" line endings
+// instead of the "\n" seen on macOS or Linux
+func TestWindowsLineEndingsWithoutArg(t *testing.T) {
+	cmdOpts := getOpts()
+	menuOpts := getMenuOpts()
+
+	menu := NewMenu(cmdOpts, menuOpts)
+
+	cmdwininvoked = false
+	cmdwinargs = []string{}
+
+	input := bytes.NewReader([]byte(fmt.Sprintf("%s\r\n", cmdwin)))
+	menu.start(input)
+
+	if !cmdwininvoked {
+		t.Error("Expected cmdwin to have been invoked")
+	}
+
+	if len(cmdwinargs) > 0 {
+		t.Error("Expected cmdwinargs to be empty")
+	}
+}
+
+// Test Windows commands, which will have "\r\n" line endings
+// instead of the "\n" seen on macOS or Linux
+func TestWindowsLineEndingsWithArg(t *testing.T) {
+	cmdOpts := getOpts()
+	menuOpts := getMenuOpts()
+
+	menu := NewMenu(cmdOpts, menuOpts)
+
+	cmdwininvoked = false
+	cmdwinargs = []string{}
+
+	arg := "hello"
+
+	input := bytes.NewReader([]byte(fmt.Sprintf("%s %s\r\n", cmdwin, arg)))
+	menu.start(input)
+
+	if !cmdwininvoked {
+		t.Error("Expected cmdwin to have been invoked")
+	}
+
+	if len(cmdwinargs) != 1 || cmdwinargs[0] != arg {
+		t.Error("Expected cmdwinargs to contain the correct argument")
+	}
 }


### PR DESCRIPTION
Fixes https://github.com/turret-io/go-menu/issues/4

Added new tests and they all pass.